### PR TITLE
Update PULL_REQUEST_TEMPLATE.md - fix committers team

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,4 +29,4 @@ A description of what steps someone could take to:
 Any additional information that you think would be helpful when reviewing this PR.
 
 # Interested parties
-Tag (@ mention) interested parties or, if unsure, @Islandora-CLAW/committers
+Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1267

# What does this Pull Request do?

Points the pull request template at the new team.

# How should this be tested?

View file & verify.

# Interested parties
Should be... @Islandora/8-x-committers ?